### PR TITLE
Use std::isnormal(), remove LazyData

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,6 @@ Authors@R:
 Description: Fiducial framework for the logistic regression model. The fiducial distribution of the parameters of the logistic regression is simulated, allowing to perform statistical inference on any parameter of interest. The algorithm is taken from Jessi Cisewski's PhD thesis: Jessi Cisewski (2012), "Generalized fiducial inference for mixed linear models".
 License: GPL-3
 Encoding: UTF-8
-LazyData: true
 RoxygenNote: 7.1.1
 SystemRequirements: C++11, gmp
 Imports:

--- a/src/gfilogisreg.cpp
+++ b/src/gfilogisreg.cpp
@@ -45,7 +45,7 @@ double forig(const arma::vec& x, const arma::mat& P, const arma::vec& b) {
 
 double f(const arma::vec& u, const arma::mat& P, const arma::vec& b) {
   double result = arma::prod(dlogis(P * from01(u) + b));
-  return isnormal(result) ? result : 0.0;
+  return std::isnormal(result) ? result : 0.0;
   //  return arma::prod(dlogis(P * from01(u) + b));
 }
 
@@ -59,7 +59,7 @@ double df(const double ui,
           const arma::vec& y2) {
   //  return y1 * dfrom01(ui) * arma::sum(Pi % y2);
   double result = y1 * dfrom01(ui) * arma::sum(Pi % y2);
-  return isnormal(result) ? result : 0.0;
+  return std::isnormal(result) ? result : 0.0;
 }
 
 double dlogf(const double ui, const arma::vec& Pi, const arma::vec& y2) {
@@ -91,7 +91,7 @@ class xF : public Functor {
     const size_t d = P.n_cols;
     const double result =
         pow(f(u, P, b), 1.0 / (d + 2)) * (from01scalar(u.at(j)) - mu.at(j));
-    return isnormal(result) ? result : 0.0;
+    return std::isnormal(result) ? result : 0.0;
   }
   void Gradient(const arma::vec& u, arma::vec& gr) override {
     const size_t d = P.n_cols;
@@ -108,7 +108,7 @@ class xF : public Functor {
       } else {
         result = alpha * z * arma::sum(P.col(i) % y2) * diff;
       }
-      gr(i) = isnormal(result) ? result : 0.0;
+      gr(i) = std::isnormal(result) ? result : 0.0;
     }
   }
 };


### PR DESCRIPTION
Salut Stephane,

As discussed over in https://github.com/eddelbuettel/bh/issues/80 I am looking in upgrading package `BH` to a new Boost version.  Your package did not build, whereas it does at CRAN, and it turns our to be a pretty bening issue that `isnormal` now clashes so switching to a more explicit `std::isnormal` fixes it.   (While at I noticed that CRAN notes an unneeded LazyData: true so I removed that too.  Feel free to reverse that part.)

It would be great if you could ship an updated `gfilogisreg` to CRAN as I plan to send `BH` there too, given that it mostly sails through cleanly.

If you have any questions just ping me.   